### PR TITLE
Agda 2.6.0 -> 2.6.0.1, agda-stdlib 1.0.1 -> 1.2

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -357,7 +357,7 @@ let
       }).overrideAttrs (oldAttrs: rec {
         # Need to override the source this way
         name = "agda-stdlib-${version}";
-        version = "1.0.1";
+        version = "1.2";
         src = sources.agda-stdlib;
       });
     };

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "http://wiki.portal.chalmers.se/agda/pmwiki.php",
         "owner": "agda",
         "repo": "agda-stdlib",
-        "rev": "v1.0.1",
-        "sha256": "0ia7mgxs5g9849r26yrx07lrx65vhlrxqqh5b6d69gfi1pykb4j2",
+        "rev": "v1.2",
+        "sha256": "01v4dy0ckir9skrn118ca4mzjnwdas70q9a9lncawjblwzikg4hq",
         "type": "tarball",
-        "url": "https://github.com/agda/agda-stdlib/archive/v1.0.1.tar.gz",
+        "url": "https://github.com/agda/agda-stdlib/archive/v1.2.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "deployment-nixpkgs": {

--- a/pkgs/default.nix
+++ b/pkgs/default.nix
@@ -137,8 +137,8 @@ license = stdenv.lib.licenses.bsd3;
 mkDerivation {
 
 pname = "Agda";
-version = "2.6.0";
-sha256 = "bf71bc634a9fe40d717aae76b5b160dfd13a06365615e7822043e5d476c06fb8";
+version = "2.6.0.1";
+sha256 = "7bb88a9cd4a556259907ccc71d54e2acc9d3e9ce05486ffdc83f721c7c06c0e8";
 isLibrary = true;
 isExecutable = true;
 enableSeparateDataOutput = true;

--- a/stack.yaml
+++ b/stack.yaml
@@ -24,7 +24,7 @@ packages:
 extra-deps:
 # Agda and deps
 - aws-lambda-haskell-runtime-2.0.1
-- Agda-2.6.0
+- Agda-2.6.0.1
 - data-hash-0.2.0.1
 - EdisonCore-1.3.2.1
 - EdisonAPI-1.3.1


### PR DESCRIPTION
Build the metatheory with this, seems to work.